### PR TITLE
Set .NET version and set always on

### DIFF
--- a/deploy/app-service.bicep
+++ b/deploy/app-service.bicep
@@ -14,6 +14,8 @@ resource app_service 'Microsoft.Web/sites@2021-02-01' = {
       vnetPrivatePortsCount: 2
       webSocketsEnabled: true
       appSettings: envVars
+      netFrameworkVersion: 'v6.0'
+      alwaysOn: true
     }
   }
 }


### PR DESCRIPTION
When I tried deploying, I noticed the default .NET version was .NET 4.8 for me. Explicitly setting this to `v6.0` fixed it. Additionally, I think apps should be always on.